### PR TITLE
Create manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,14 @@
+{
+  "domain": "coupled_alarms",
+  "name": "Coupled Alarms",
+  "documentation": "https://github.com/cadavre/coupled_alarms",
+  "issue_tracker": "https://github.com/cadavre/coupled_alarms/issues",
+  "dependencies": [],
+  "config_flow": false,
+  "version": "1",
+  "codeowners": [
+    "@cadavre"
+  ],
+  "requirements": [],
+  "iot_class": "local_push"
+}


### PR DESCRIPTION
As per https://www.home-assistant.io/blog/2021/06/02/release-20216/#breaking-changes custom_components will not be loaded if there is no manifest file